### PR TITLE
Hotfix: Corrigeer verkeerde toewijzing van Admin-rol

### DIFF
--- a/Grocery.Core.Data/Repositories/ClientRepository.cs
+++ b/Grocery.Core.Data/Repositories/ClientRepository.cs
@@ -13,7 +13,7 @@ namespace Grocery.Core.Data.Repositories
         {
             clientList = [
                 new Client(1, "M.J. Curie", "user1@mail.com", "IunRhDKa+fWo8+4/Qfj7Pg==.kDxZnUQHCZun6gLIE6d9oeULLRIuRmxmH2QKJv2IM08="),
-                new Client(2, "H.H. Hermans", "user2@mail.com", "dOk+X+wt+MA9uIniRGKDFg==.QLvy72hdG8nWj1FyL75KoKeu4DUgu5B/HAHqTD2UFLU=") { Role = Role.Admin },
+                new Client(2, "H.H. Hermans", "user2@mail.com", "dOk+X+wt+MA9uIniRGKDFg==.QLvy72hdG8nWj1FyL75KoKeu4DUgu5B/HAHqTD2UFLU="),
                 new Client(3, "A.J. Kwak", "user3@mail.com", "sxnIcZdYt8wC8MYWcQVQjQ==.FKd5Z/jwxPv3a63lX+uvQ0+P7EuNYZybvkmdhbnkIHA=") { Role = Role.Admin },
             ];
         }


### PR DESCRIPTION
**Beschrijving**

Deze hotfix verhelpt een fout waarbij de Admin-rol per ongeluk was gekoppeld aan het verkeerde account.
De wijziging zorgt ervoor dat alleen de juiste gebruiker (user3) de Admin-rechten krijgt, en de foutieve koppeling wordt verwijderd.

**Impact:**

Beveiliging: voorkomt dat een niet-bevoegd account Admin-toegang heeft.

Correcte functionaliteit voor het bekijken van gekochte producten en andere Admin-features.